### PR TITLE
feat: bump software-star to 1.1.2 and set 4Gb memory limit for STAR alignment

### DIFF
--- a/.changeset/star-memory-limit.md
+++ b/.changeset/star-memory-limit.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.star-read-mapping': patch
+---
+
+Set 4Gb memory limit for STAR alignment step

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ catalogs:
       specifier: ~1.15.25
       version: 1.15.25
     '@platforma-open/milaboratories.software-star':
-      specifier: ~1.1.1
-      version: 1.1.1
+      specifier: ~1.1.2
+      version: 1.1.2
     '@platforma-open/milaboratories.software-subread':
       specifier: ~1.0.2
       version: 1.0.2
@@ -246,7 +246,7 @@ importers:
         version: 1.15.25
       '@platforma-open/milaboratories.software-star':
         specifier: 'catalog:'
-        version: 1.1.1
+        version: 1.1.2
       '@platforma-open/milaboratories.software-subread':
         specifier: 'catalog:'
         version: 1.0.2
@@ -1067,8 +1067,8 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@1.15.25':
     resolution: {integrity: sha512-4y+YduAMh2C0jfjZHm2MSNShr4X/Qwzk67TUIHeV0qW3oDoT2NxDdd1IhpCN0Iw1Egxm+MM7X8eV9mS1Bq0PUg==}
 
-  '@platforma-open/milaboratories.software-star@1.1.1':
-    resolution: {integrity: sha512-w7MvWbjBP6hMs9nlmZCvG4zC3oFb4Zg01I/XPmSQ73LPLq9l4WliJPHdiYHqEWerchGyWa51NHyVL4ecgpi1Ng==}
+  '@platforma-open/milaboratories.software-star@1.1.2':
+    resolution: {integrity: sha512-rYeCkHJHC0F5OUiq1EI4+4akRVPtjvMzcnRvdl1Kgx3fae7z3ex25xzuc8/E09UCDOiSihHsIodLWADc0vpCVA==}
 
   '@platforma-open/milaboratories.software-subread@1.0.2':
     resolution: {integrity: sha512-8C3qjZS6JFD4xqFl96GaR94RzXS/w7Q4S2RRziC66/2dK/b9pzH1I2iXKZ5m3aeXaH2GlEXYvoFLGscigSVPCQ==}
@@ -6826,7 +6826,7 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.small-asset': 1.1.4
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.2
 
-  '@platforma-open/milaboratories.software-star@1.1.1': {}
+  '@platforma-open/milaboratories.software-star@1.1.2': {}
 
   '@platforma-open/milaboratories.software-subread@1.0.2': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ catalog:
   '@milaboratories/software-pframes-conv': ~2.2.9
   '@platforma-open/milaboratories.software-small-binaries': ~1.15.25
   '@platforma-open/milaboratories.software-subread': ~1.0.2
-  '@platforma-open/milaboratories.software-star': ~1.1.1
+  '@platforma-open/milaboratories.software-star': ~1.1.2
   '@platforma-open/milaboratories.genome-assets': 1.2.0
   '@platforma-open/milaboratories.runenv-r-normalize-counts': ~1.0.6
   '@platforma-open/milaboratories.runenv-r-sample-qc': ~1.0.5

--- a/workflow/src/star-alignment.tpl.tengo
+++ b/workflow/src/star-alignment.tpl.tengo
@@ -54,7 +54,8 @@ self.body(func(inputs) {
 		addAsset(genomeAssets, "genomeIndex", ["transcriptInfo.tab"]).
 		arg("--genomeDir").arg("genomeIndex").
 		arg("--outSAMtype").arg("BAM").arg("SortedByCoordinate").
-		arg("--readFilesIn")
+		arg("--readFilesIn").
+		mem("4Gb")
 
 	nReads := 0
 	filesByRIndex := {}


### PR DESCRIPTION
## Purpose

Upgrades STAR software package to 1.1.2 and enforces a 4Gb memory ceiling on the alignment job to prevent OOM failures in resource-constrained environments (K8s).

## Changes

- Bump `software-star` from 1.1.1 → 1.1.2
- Add `.mem("4Gb")` to the STAR alignment workflow step
- Add `dash` system dependency to the R software Dockerfile
- Fix Bioconductor repository URL in renv.lock files (books → bioc)
- Migrate catalog version specifiers from `^` (compatible) to `~` (patch-level only)
- Bump `package-builder` from 3.10.7 → 3.11.4

## Tests

No new tests — dependency and config changes; STAR workflow behavior is covered by existing integration tests.