### PR TITLE
Bump STAR memory request from 4 GB to 32 GiB

### DIFF
--- a/.changeset/fix-star-memory-localfs.md
+++ b/.changeset/fix-star-memory-localfs.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.star-read-mapping.workflow': patch
+---
+
+Bump STAR memory request from 4 GB to 32 GiB. Loading the human GRCh38 STAR index requires ~30 GB resident; the previous 4 GB allocation caused the STAR process (and on localfs deployments often the backend itself) to be OOM-killed mid-run, surfacing as `Emergency bootstrap mode enabled - command marked as failed to escape failure loop` after backend restart. 32 GiB matches what STAR typically needs for mammalian genomes; on smaller hosts the queue scheduler caps the request at the queue limit, and small genomes (yeast, test species) use only a fraction of the request.

--- a/.changeset/fix-star-memory-localfs.md
+++ b/.changeset/fix-star-memory-localfs.md
@@ -2,4 +2,15 @@
 '@platforma-open/milaboratories.star-read-mapping.workflow': patch
 ---
 
-Bump STAR memory request from 4 GB to 32 GiB. Loading the human GRCh38 STAR index requires ~30 GB resident; the previous 4 GB allocation caused the STAR process (and on localfs deployments often the backend itself) to be OOM-killed mid-run, surfacing as `Emergency bootstrap mode enabled - command marked as failed to escape failure loop` after backend restart. 32 GiB matches what STAR typically needs for mammalian genomes; on smaller hosts the queue scheduler caps the request at the queue limit, and small genomes (yeast, test species) use only a fraction of the request.
+Set STAR memory request per genome instead of the previous hardcoded `mem("4Gb")`. STAR's memory footprint is dominated by mmap of the suffix-array index, which scales with genome size; the 4 GB request was below what mammalian genomes need (~30 GB resident for human GRCh38) and caused STAR (and on localfs deployments often the backend itself) to be OOM-killed mid-run, surfacing as `Emergency bootstrap mode enabled - command marked as failed to escape failure loop` after the next backend start.
+
+Per-species sizing (chosen for ~1.5× genome size + overhead):
+
+| genome | mem |
+| --- | --- |
+| `saccharomyces-cerevisiae`, `test-species` | 2 GiB |
+| `drosophila-melanogaster`, `arabidopsis-thaliana`, `caenorhabditis-elegans` | 4 GiB |
+| `danio-rerio`, `gallus-gallus` | 16 GiB |
+| `homo-sapiens`, `mus-musculus`, `rattus-norvegicus`, `bos-taurus`, `sus-scrofa` (and unknown) | 32 GiB |
+
+Pinning per genome rather than relying on heavy-queue defaults insulates the block from future changes to the queue's default memory allocation.

--- a/workflow/src/star-alignment.tpl.tengo
+++ b/workflow/src/star-alignment.tpl.tengo
@@ -55,7 +55,7 @@ self.body(func(inputs) {
 		arg("--genomeDir").arg("genomeIndex").
 		arg("--outSAMtype").arg("BAM").arg("SortedByCoordinate").
 		arg("--readFilesIn").
-		mem("4Gb")
+		mem("32GiB")
 
 	nReads := 0
 	filesByRIndex := {}

--- a/workflow/src/star-alignment.tpl.tengo
+++ b/workflow/src/star-alignment.tpl.tengo
@@ -33,6 +33,20 @@ self.body(func(inputs) {
 
 	inputDataMeta := inputData.getDataAsJson()
 
+	// STAR memory is dominated by mmap of the suffix-array index, which scales
+	// with genome size. Pin the request per species rather than relying on
+	// queue defaults so it stays correct if heavy-queue defaults are retuned.
+	starMem := "32GiB"
+	if species == "saccharomyces-cerevisiae" || species == "test-species" {
+		starMem = "2GiB"
+	} else if species == "drosophila-melanogaster" || species == "arabidopsis-thaliana" || species == "caenorhabditis-elegans" {
+		starMem = "4GiB"
+	} else if species == "danio-rerio" || species == "gallus-gallus" {
+		starMem = "16GiB"
+	}
+	// Mammalian (homo-sapiens, mus-musculus, rattus-norvegicus, bos-taurus,
+	// sus-scrofa) and unknown genomes fall through to 32GiB.
+
 	star:= exec.builder().
 		software(assets.importSoftware("@platforma-open/milaboratories.software-star:star")).
 		mkDir("genomeIndex").
@@ -55,7 +69,7 @@ self.body(func(inputs) {
 		arg("--genomeDir").arg("genomeIndex").
 		arg("--outSAMtype").arg("BAM").arg("SortedByCoordinate").
 		arg("--readFilesIn").
-		mem("32GiB")
+		mem(starMem)
 
 	nReads := 0
 	filesByRIndex := {}


### PR DESCRIPTION
## Summary
Fix STAR `mem("4Gb")` allocation, which is grossly insufficient for mammalian genomes. STAR's memory footprint is dominated by mmap of the suffix-array index and scales with genome size — human GRCh38 needs ~30 GB resident just to load. With only 4 GB allocated, STAR (and on localfs deployments often the backend itself) gets OOM-killed, surfacing as `Emergency bootstrap mode enabled - command marked as failed to escape failure loop` and a sample stuck at "loading genome 0%" (see ticket screenshot).

Pick the request per genome rather than relying on heavy-queue defaults (~1.5× genome size + overhead):

| genome | mem |
| --- | --- |
| `saccharomyces-cerevisiae`, `test-species` | 2 GiB |
| `drosophila-melanogaster`, `arabidopsis-thaliana`, `caenorhabditis-elegans` | 4 GiB |
| `danio-rerio`, `gallus-gallus` | 16 GiB |
| `homo-sapiens`, `mus-musculus`, `rattus-norvegicus`, `bos-taurus`, `sus-scrofa` (and unknown) | 32 GiB |

Pinning per genome rather than leaning on the heavy-queue default insulates the block from future changes to the queue's default memory allocation.

Fixes the bug reported in MILAB-6241.

## Test plan
- [ ] Run STAR Read Mapping on a localfs backend (3.4.1) with `homo-sapiens` GRCh38 + small bulk RNA-seq dataset and confirm alignment completes.
- [ ] Run with `saccharomyces-cerevisiae` / `test-species` and confirm the smaller 2 GiB request still completes (and frees scheduler capacity for other work).
- [ ] Run with each tier (`drosophila-melanogaster`, `danio-rerio`, etc.) and confirm no regression.
- [ ] On a host with <32 GiB total RAM, confirm `homo-sapiens` is still scheduled (queue caps the request rather than blocking) and small genomes are unaffected.