### PR TITLE
Fix non-deterministic R1/R2 order in STAR --readFilesIn (single-key inputs)

### DIFF
--- a/.changeset/fix-star-readfiles-order.md
+++ b/.changeset/fix-star-readfiles-order.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.star-read-mapping.workflow': patch
+---
+
+Fix non-deterministic R1/R2 order in STAR `--readFilesIn` for single-key (lane-less) input. Read-file args were added during a `for sKey, inputFile in inputData.inputs()` loop, which has non-deterministic iteration order. When STAR received `--readFilesIn input_R2.fq.gz input_R1.fq.gz`, it either failed with `wrong read ID line format` or produced a BAM that featureCounts then rejected with `No paired-end reads were detected in paired-end read library`. Args are now added in a separate loop in fixed `R1` then `R2` order, mirroring the multi-lane (keyLength==2) path.

--- a/workflow/src/star-alignment.tpl.tengo
+++ b/workflow/src/star-alignment.tpl.tengo
@@ -59,6 +59,7 @@ self.body(func(inputs) {
 
 	nReads := 0
 	filesByRIndex := {}
+	fileNamesByRIndex := {}
 	if inputDataMeta.keyLength == 1 {
 		ll.assert(aggregationAxesNames == ["pl7.app/sequencing/readIndex"], "unexpected aggregation axes names")
 		for sKey, inputFile in inputData.inputs() {
@@ -68,16 +69,24 @@ self.body(func(inputs) {
 				ll.panic("malformed read index: %v", r)
 			}
 			fileName := "input_" + r + "." + fileExtension
-			star.addFile(fileName, inputFile).arg(fileName)
+			star.addFile(fileName, inputFile)
 			filesByRIndex[r] = inputFile
+			fileNamesByRIndex[r] = fileName
 		}
 
+		// Add read file args in deterministic order (R1 before R2). Map iteration
+		// is non-deterministic, so combining addFile + arg in the loop above can
+		// produce --readFilesIn input_R2.fq.gz input_R1.fq.gz, which puts R2 in
+		// STAR's read1 slot. STAR may then either fail with "wrong read ID line
+		// format" or produce a BAM that featureCounts -p rejects with "No
+		// paired-end reads were detected".
 		for rIndex in ["R1", "R2"] {
 			inputFile := filesByRIndex[rIndex]
 			if is_undefined(inputFile) {
 				continue
 			}
 			nReads = nReads + 1
+			star.arg(fileNamesByRIndex[rIndex])
 		}
 		ll.assert(nReads != 0, "No R read indexes")
 	} else if inputDataMeta.keyLength == 2 {


### PR DESCRIPTION
## Summary
- In the `keyLength == 1` (lane-less) branch of `star-alignment.tpl.tengo`, read-file args were added during a `for sKey, inputFile in inputData.inputs()` loop. Tengo map iteration order is non-deterministic, so STAR could be invoked with `--readFilesIn input_R2.fq.gz input_R1.fq.gz`, placing R2 in the read1 slot.
- Two observed failure modes:
  - STAR exits with `wrong read ID line format` (no BAM produced).
  - STAR completes and emits a BAM whose reads lack the paired-end SAM flag, which featureCounts `-p` then rejects with `No paired-end reads were detected in paired-end read library : sample_Aligned.sortedByCoord.out.bam` (exit code 255). Surfaced after the memory fix in #83 unblocked STAR enough to produce a BAM.
- Add read-file args in a separate post-iteration loop in fixed `R1` → `R2` order, mirroring what the `keyLength == 2` (multi-lane) branch already does. This re-applies the MILAB-4761 fix that was prepared on `MILAB-4761/fix-read-order` (commits `ed80fd1`, `d94759f`) but never merged into `main`.

Pairs with #83 (memory fix) — both are needed to run the block on real human/mouse RNA-seq input on localfs.

## Test plan
- [ ] Run STAR Read Mapping with paired-end FASTQ (single-lane / `keyLength == 1`) and confirm featureCounts no longer errors with `No paired-end reads were detected`.
- [ ] Confirm the produced `sample_Aligned.sortedByCoord.out.bam` has reads flagged as paired-end (`samtools view -c -f 1` > 0).
- [ ] Run with single-end input (only `R1`) and confirm `nReads == 1`, no `-p` passed to featureCounts, and the block still completes.
- [ ] Run with multi-lane paired input (`keyLength == 2`) and confirm no regression in that path (it was already deterministic).