### PR TITLE
MILAB-6263: fix renv runtime permission-denied on non-root containers

### DIFF
--- a/.changeset/fix-runtime-renv-restore-permission-denied.md
+++ b/.changeset/fix-runtime-renv-restore-permission-denied.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.star-read-mapping.software": patch
+---
+
+Fix runtime `Permission denied` when the container runs as a non-root UID (MILAB-6263). The entrypoint re-invoked `renv::restore()` on every start, which tries to reconcile the system R library at `/usr/local/lib/R/site-library/` with the project lockfile. When the `r-base:4.4.2` base image preinstalled a version of a locked package (e.g. `rlang`) that differs from `renv.lock`, renv attempted to back up the system-library copy before replacing it — failing on hosts that run the container unprivileged. renv now installs into a project-local library at `/app/renv/library` and `R_LIBS_USER` points R at the same path, so the obsolete `/app/run.sh` wrapper and runtime restore are removed.

--- a/software/Dockerfile
+++ b/software/Dockerfile
@@ -8,31 +8,31 @@ ENV RENV_CONFIG_REPOS_OVERRIDE=https://cloud.r-project.org
 
 # Install system dependencies required for R packages
 RUN apt-get update && apt-get install -y \
-    curl \
     ca-certificates \
+    curl \
     dash \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    libxml2-dev \
-    libcairo2-dev \
-    libgit2-dev \
     default-libmysqlclient-dev \
+    libbz2-dev \
+    libcairo2-dev \
+    libcurl4-openssl-dev \
+    libfreetype6-dev \
+    libfribidi-dev \
+    libgit2-dev \
+    libgsl-dev \
+    libharfbuzz-dev \
+    libjpeg-dev \
+    liblzma-dev \
+    libpcre2-dev \
+    libpng-dev \
     libpq-dev \
     libsasl2-dev \
     libsqlite3-dev \
     libssh2-1-dev \
-    unixodbc-dev \
-    libharfbuzz-dev \
-    libfribidi-dev \
-    libfreetype6-dev \
-    libpng-dev \
+    libssl-dev \
     libtiff5-dev \
-    libjpeg-dev \
-    libgsl-dev \
-    libbz2-dev \
-    liblzma-dev \
-    libpcre2-dev \
     libuv1-dev \
+    libxml2-dev \
+    unixodbc-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -65,4 +65,5 @@ RUN mkdir -p "${R_LIBS_USER}"
 # (e.g. ggplot2 starting before tibble is visible in the library).
 RUN R --no-echo -e "tryCatch(renv::restore(), error = function(e) message('parallel pass finished with errors: ', conditionMessage(e))); options(Ncpus = 1); renv::restore(clean = TRUE)" \
     && find /root/.cache/R -name keys.html -delete \
-    && find /usr/local/lib/R -name keys.html -delete
+    && find /usr/local/lib/R -name keys.html -delete \
+    && find "${R_LIBS_USER}" -name keys.html -delete

--- a/software/Dockerfile
+++ b/software/Dockerfile
@@ -49,15 +49,18 @@ COPY ./renv.lock ./renv.lock
 ENV RENV_PATHS_RENV=/app/renv
 ENV RENV_PATHS_LOCKFILE=/app/renv.lock
 
+# Direct renv to install into a project-local library (instead of the
+# system-wide /usr/local/lib/R/site-library) and expose that path to R via
+# R_LIBS_USER so Rscript finds the packages at runtime without any renv code.
+ENV R_LIBS_USER=/app/renv/library
+ENV RENV_PATHS_LIBRARY=${R_LIBS_USER}
+
+# Yes, we have to create it manually. Otherwise default will be used silently.
+RUN mkdir -p "${R_LIBS_USER}"
+
 # First pass: parallel install (fast for the bulk of packages).
 # Second pass: sequential retry to resolve any parallel-install races
 # (e.g. ggplot2 starting before tibble is visible in the library).
 RUN R --no-echo -e "tryCatch(renv::restore(), error = function(e) message('parallel pass finished with errors: ', conditionMessage(e))); options(Ncpus = 1); renv::restore(clean = TRUE)" \
     && find /root/.cache/R -name keys.html -delete \
     && find /usr/local/lib/R -name keys.html -delete
-
-RUN echo "#!/bin/bash\nR --no-echo --no-restore -e \"renv::restore()\"\n\"\$@\"" > /app/run.sh
-RUN chmod +x /app/run.sh
-
-# Default command runs Rscript
-ENTRYPOINT ["/app/run.sh"]

--- a/software/Dockerfile
+++ b/software/Dockerfile
@@ -10,6 +10,7 @@ ENV RENV_CONFIG_REPOS_OVERRIDE=https://cloud.r-project.org
 RUN apt-get update && apt-get install -y \
     curl \
     ca-certificates \
+    dash \
     libcurl4-openssl-dev \
     libssl-dev \
     libxml2-dev \
@@ -31,6 +32,7 @@ RUN apt-get update && apt-get install -y \
     libbz2-dev \
     liblzma-dev \
     libpcre2-dev \
+    libuv1-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
Cross-block fix: the docker entrypoint of the R-based software re-ran `renv::restore()` on every container start. On hosts that run the container as a non-root UID (e.g. lab.research), renv tried to back up entries in the root-owned `/usr/local/lib/R/site-library/` (e.g. `rlang` brought in by the `r-base:4.4.2` base image) and failed with `Permission denied`.

Already merged in `differential-clonotype-abundance` (platforma-open/differential-clonotype-abundance#43); the same `Dockerfile` pattern was replicated here.

## Change
- `ENV R_LIBS_USER=/app/renv/library` + `ENV RENV_PATHS_LIBRARY=\${R_LIBS_USER}` so renv installs into a project-local library and R discovers packages via the standard `R_LIBS_USER` env var.
- `RUN mkdir -p \"\${R_LIBS_USER}\"` because renv silently falls back to the default library if the path doesn't exist.
- Drop `/app/run.sh` and the `ENTRYPOINT`; the platforma SDK passes the full `cmd` (`Rscript /app/...`) at run time, so no wrapper is needed.

## Test plan
- [ ] CI build of the docker image succeeds.
- [ ] On a non-root host (lab.research), running the entrypoint no longer logs `cannot create directory '/usr/local/lib/R/site-library/...': Permission denied`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `Permission denied` error that occurred at runtime when the container ran as a non-root UID. The root cause was the `run.sh` entrypoint re-invoking `renv::restore()` on every container start, which attempted to modify the root-owned `/usr/local/lib/R/site-library/`.

- **Library path redirect**: `R_LIBS_USER` and `RENV_PATHS_LIBRARY` now both point to `/app/renv/library`, so all renv package installs happen in a project-local, writable location inside the image layer rather than the system library.
- **`mkdir -p` guard**: The library directory is pre-created at build time, preventing renv from silently falling back to the system path if the directory doesn't exist.
- **Entrypoint removed**: The `run.sh` wrapper (which triggered the failing `renv::restore()` at startup) and its `ENTRYPOINT` declaration are dropped; the platforma SDK now supplies the full `Rscript` command directly.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a focused, well-scoped fix that has already been validated in a parallel repo (differential-clonotype-abundance#43).

The fix correctly redirects renv's install target to a project-local, writable path baked into the image layer, eliminates the runtime restore that caused the failure, and mirrors a change already merged and tested elsewhere. The mkdir -p guard correctly prevents the silent fallback. No logic regressions are introduced and the entrypoint removal is consistent with how the SDK supplies the run command.

No files require special attention; both changed files are straightforward and consistent with each other.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| software/Dockerfile | Core fix: redirects renv's install library to /app/renv/library via R_LIBS_USER/RENV_PATHS_LIBRARY, pre-creates the directory, and removes the run.sh entrypoint that triggered the failing runtime restore. |
| .changeset/fix-runtime-renv-restore-permission-denied.md | New changeset entry documenting the patch-level fix; description accurately reflects the root cause and resolution. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph BEFORE["Before (broken on non-root)"]
        A1["Container starts"] --> B1["/app/run.sh ENTRYPOINT"]
        B1 --> C1["R -e 'renv::restore()'"]
        C1 --> D1{"Non-root UID?"}
        D1 -->|Yes| E1["❌ Permission denied\n/usr/local/lib/R/site-library/"]
        D1 -->|No| F1["✅ renv restores to\n/usr/local/lib/R/site-library/"]
        F1 --> G1["Rscript /app/..."]
    end

    subgraph AFTER["After (fixed)"]
        A2["Docker build"] --> B2["R_LIBS_USER=/app/renv/library\nRENV_PATHS_LIBRARY=/app/renv/library"]
        B2 --> C2["mkdir -p /app/renv/library"]
        C2 --> D2["renv::restore() at BUILD TIME\ninstalls into /app/renv/library"]
        D2 --> E2["Image layer contains\ncomplete package library"]
        E2 --> F2["Container starts\n(SDK supplies: Rscript /app/...)"]
        F2 --> G2["R finds packages via\nR_LIBS_USER at runtime"]
        G2 --> H2["✅ No renv::restore()\nat runtime — no permission issue"]
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6263: align Dockerfile across all ..."](https://github.com/platforma-open/star-read-mapping/commit/e31c77cac4719405a250d958e5bc45e28a34fa78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31795033)</sub>

<!-- /greptile_comment -->